### PR TITLE
Feature: Sync filter and URL parameters

### DIFF
--- a/src/app/components/filter.component.ts
+++ b/src/app/components/filter.component.ts
@@ -129,6 +129,12 @@ export interface Filter {
         }
       }
     }
+
+    @media (max-width: 768px) {
+      #filter-form {
+        flex-direction: column;
+      }
+    }
   `,
   providers: [
     {
@@ -168,7 +174,7 @@ export class FilterComponent implements ControlValueAccessor {
     this.filterForm.valueChanges
       .pipe(
         takeUntilDestroyed(),
-        map(() => this.filterForm.getRawValue())
+        map(() => this.filterForm.getRawValue()),
       )
       .subscribe((filter) => {
         this.changed(filter);

--- a/src/app/components/filter.component.ts
+++ b/src/app/components/filter.component.ts
@@ -1,0 +1,193 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  forwardRef,
+  inject,
+  input,
+  output,
+} from '@angular/core';
+import {
+  ControlValueAccessor,
+  FormBuilder,
+  FormControl,
+  FormGroup,
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+} from '@angular/forms';
+
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { map } from 'rxjs';
+
+import { ButtonModule } from 'primeng/button';
+import { DropdownModule } from 'primeng/dropdown';
+import { TriStateCheckboxModule } from 'primeng/tristatecheckbox';
+
+type FormGroupOf<TForm> = FormGroup<{
+  [TKey in keyof TForm]: FormControl<TForm[TKey]>;
+}>;
+
+export interface Filter {
+  category: string | null;
+  versionGroup: string | null;
+  analogVersion: string | null;
+  uiLib: string | null;
+  isFree: boolean | null;
+  isUsing3D: boolean | null;
+}
+
+@Component({
+  selector: 'app-filter',
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    DropdownModule,
+    ButtonModule,
+    TriStateCheckboxModule,
+  ],
+  template: `
+    <form id="filter-form" [formGroup]="filterForm">
+      <p-dropdown
+        formControlName="category"
+        [options]="projectCategories()"
+        placeholder="Category"
+      />
+
+      <p-dropdown
+        formControlName="versionGroup"
+        [options]="angularVersions()"
+        placeholder="Angular Version"
+      />
+
+      <p-dropdown
+        formControlName="analogVersion"
+        [options]="analogVersions()"
+        placeholder="Analog Version"
+      />
+
+      <p-dropdown
+        formControlName="uiLib"
+        [options]="uiLibs()"
+        placeholder="UI Library"
+      />
+
+      <div class="buttons-wrapper">
+        <div class="checkbox-wrapper">
+          <p-triStateCheckbox
+            formControlName="isFree"
+            label="Free"
+            binary
+            name="free"
+          />
+        </div>
+
+        <div class="checkbox-wrapper">
+          <p-triStateCheckbox
+            formControlName="isUsing3D"
+            label="3D"
+            binary
+            name="3D"
+          />
+        </div>
+      </div>
+
+      <div>
+        <p-button label="Clear Filters" (onClick)="reset()" />
+      </div>
+    </form>
+  `,
+  styles: `
+    #filter-form {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+
+      .p-dropdown {
+        width: 13rem;
+      }
+
+      .buttons-wrapper {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        justify-content: center;
+        gap: 0.3rem;
+
+        .checkbox-wrapper {
+          display: flex;
+          align-items: center;
+          gap: 0.3rem;
+          margin: 0 0.5rem;
+
+          .p- checkbox {
+            height: 1.1rem;
+            width: 1.1rem;
+            cursor: pointer;
+          }
+          label {
+            font-size: 1.1rem;
+          }
+        }
+      }
+    }
+  `,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => FilterComponent),
+      multi: true,
+    },
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FilterComponent implements ControlValueAccessor {
+  readonly #fb = inject(FormBuilder);
+
+  readonly analogVersions = input.required<string[]>();
+
+  readonly angularVersions = input.required<string[]>();
+
+  readonly projectCategories = input.required<string[]>();
+
+  readonly uiLibs = input.required<string[]>();
+
+  readonly filterForm: FormGroupOf<Filter>;
+
+  changed: (filter: Filter) => void = () => {};
+  touched: () => void = () => {};
+
+  constructor() {
+    this.filterForm = this.#fb.group({
+      category: this.#fb.control<string | null>(null),
+      versionGroup: this.#fb.control<string | null>(null),
+      analogVersion: this.#fb.control<string | null>(null),
+      uiLib: this.#fb.control<string | null>(null),
+      isFree: this.#fb.control<boolean | null>(null),
+      isUsing3D: this.#fb.control<boolean | null>(null),
+    });
+
+    this.filterForm.valueChanges
+      .pipe(
+        takeUntilDestroyed(),
+        map(() => this.filterForm.getRawValue())
+      )
+      .subscribe((filter) => {
+        this.changed(filter);
+        this.touched();
+      });
+  }
+  writeValue(filter: Filter | null): void {
+    filter === null ? this.reset() : this.filterForm.setValue(filter);
+  }
+
+  registerOnChange(fn: (filter: Filter) => {}): void {
+    this.changed = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.touched = fn;
+  }
+
+  reset(): void {
+    this.filterForm.reset();
+  }
+}

--- a/src/app/pages/(home).page.ts
+++ b/src/app/pages/(home).page.ts
@@ -1,509 +1,534 @@
-import { HttpClient } from "@angular/common/http";
-import { Component, inject, OnChanges, OnInit } from "@angular/core";
-import { Project } from "../models/project";
-import { FormsModule } from "@angular/forms";
+import { HttpClient } from '@angular/common/http';
+import {
+  Component,
+  effect,
+  inject,
+  model,
+  OnChanges,
+  OnInit,
+  untracked,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Project } from '../models/project';
 
-import { DropdownModule } from "primeng/dropdown";
-import { CardModule } from "primeng/card";
-import { ButtonModule } from "primeng/button";
-import { CheckboxModule } from "primeng/checkbox";
-import { TooltipModule } from "primeng/tooltip";
+import { ActivatedRoute, Router } from '@angular/router';
+import { ButtonModule } from 'primeng/button';
+import { CardModule } from 'primeng/card';
+import { CheckboxModule } from 'primeng/checkbox';
+import { DropdownModule } from 'primeng/dropdown';
+import { TooltipModule } from 'primeng/tooltip';
+import { Filter, FilterComponent } from '../components/filter.component';
 
 @Component({
-	selector: "app-home",
-	standalone: true,
-	imports: [
-		FormsModule,
-		DropdownModule,
-		CardModule,
-		ButtonModule,
-		CheckboxModule,
-		TooltipModule,
-	],
-	template: `
-		<div class="content">
-			<div class="filtering">
-				<div class="filtering-actions">
-					<p-dropdown
-						[options]="categories"
-						[(ngModel)]="selectedCategory"
-						optionLabel="name"
-						(onChange)="applyFilter()"
-						placeholder="Category"
-					/>
-					<p-dropdown
-						[options]="versionGroup"
-						[(ngModel)]="selectedVersionGroup"
-						optionLabel="name"
-						(onChange)="applyFilter()"
-						placeholder="Angular Version"
-					/>
-					<p-dropdown
-						[options]="analogVersions"
-						[(ngModel)]="selectedAnalogVersion"
-						optionLabel="name"
-						(onChange)="applyFilter()"
-						placeholder="Analog Version"
-					/>
-					<p-dropdown
-						[options]="projectsUIlib"
-						[(ngModel)]="selectedUIlib"
-						optionLabel="name"
-						(onChange)="applyFilter()"
-						placeholder="UI Library"
-					/>
-					<div class="buttons-wrapper">
-						<div class="checkbox-wrapper">
-							<p-checkbox
-								[(ngModel)]="showFree"
-								label="Free"
-								[binary]="true"
-								name="free"
-								(onChange)="applyFilter()"
-							/>
-						</div>
-						<div class="checkbox-wrapper">
-							<p-checkbox
-								[(ngModel)]="threeDElements"
-								label="3D"
-								[binary]="true"
-								name="3D"
-								(onChange)="applyFilter()"
-							/>
-						</div>
-					</div>
-					<p-button label="Clear Filters" (click)="clearFilters()" />
-				</div>
-				<div class="total">
-					@if (!filterApplied) {
-					<p>All Projects: {{ projects.length }}</p>
-					} @else {
-					<p>Projects found: {{ filteredProjects.length }}</p>
-					}
-				</div>
-			</div>
-			<div class="cards-wrapper">
-				@if (!filterApplied) { @for (project of projects; track project) {
-				<a href="{{ project.url }}?source=builtwithanalog.dev" target="_blank">
-					<p-card class="home">
-						<img
-							class="main-image"
-							src="{{ project.imageSrc }}"
-							alt="{{ project.name }}"
-							pTooltip="by {{ project.developer }}"
-							tooltipPosition="bottom"
-						/>
-						<div class="card-content">
-							<div class="details">
-								<div class="info">
-									<div class="main">
-										@if (project.category.includes("Open Source") ||
-										project.pricing === "Free") {
-										<h2>{{ project.name }}</h2>
-										} @else {
-										<span
-											class="material-symbols-outlined"
-											title="{{ project.pricing }}"
-										>
-											paid
-										</span>
-										<h2>{{ project.name }}</h2>
-										}
-									</div>
-									<div class="more">
-										<p>{{ project.category }}</p>
-									</div>
-								</div>
-								<div class="features">
-									<div class="version">
-										<img
-											class="analog"
-											src="/icons/analog.svg"
-											pTooltip="{{ project.analogVersion }}"
-											tooltipPosition="top"
-										/>
-										@if (isVersion16OrAbove(project.version)) {
-										<img
-											src="/icons/angular.svg"
-											pTooltip="{{ project.version }}"
-											tooltipPosition="top"
-										/>
-										} @else {
-										<img
-											src="/angular-old.svg"
-											pTooltip="{{ project.version }}"
-											tooltipPosition="top"
-										/>
-										}
-									</div>
-									<div class="ui">
-										@if (project.uiLib.includes('Spartan UI')) {
-										<img
-											class="ui-lib"
-											src="/icons/spartan.png"
-											pTooltip="Spartan UI"
-											tooltipPosition="top"
-										/>
-										} @if (project.uiLib.includes('PrimeNG')) {
-										<img
-											class="ui-lib"
-											src="/icons/primeng.svg"
-											pTooltip="PrimeNG"
-											tooltipPosition="top"
-										/>
-										} @if (project.uiLib.includes('Tailwind CSS')) {
-										<img
-											class="ui-lib"
-											src="/icons/tailwind.svg"
-											pTooltip="Tailwind CSS"
-											tooltipPosition="top"
-										/>
-										}
-									</div>
-								</div>
-							</div>
-						</div>
-					</p-card>
-				</a>
-				} } @else { @for (project of filteredProjects; track project) {
-				<a href="{{ project.url }}?source=builtwithanalog.dev" target="_blank">
-					<p-card class="home">
-						<img
-							class="main-image"
-							src="{{ project.imageSrc }}"
-							alt="{{ project.name }}"
-							pTooltip="by {{ project.developer }}"
-							tooltipPosition="bottom"
-						/>
-						<div class="card-content">
-							<div class="details">
-								<div class="info">
-									<div class="main">
-										@if (project.category.includes("Open Source") ||
-										project.pricing === "Free") {
-										<h2>{{ project.name }}</h2>
-										} @else {
-										<span
-											class="material-symbols-outlined"
-											title="{{ project.pricing }}"
-										>
-											paid
-										</span>
-										<h2>{{ project.name }}</h2>
-										}
-									</div>
-									<div class="more">
-										<p>{{ project.category }}</p>
-									</div>
-								</div>
-								<div class="features">
-									<div class="version">
-										<img
-											class="analog"
-											src="/icons/analog.svg"
-											pTooltip="{{ project.analogVersion }}"
-											tooltipPosition="top"
-										/>
-										@if (isVersion16OrAbove(project.version)) {
-										<img
-											src="/icons/angular.svg"
-											pTooltip="{{ project.version }}"
-											tooltipPosition="top"
-										/>
-										} @else {
-										<img
-											src="/icons/angular-old.svg"
-											pTooltip="{{ project.uiLib }}"
-											tooltipPosition="top"
-										/>
-										}
-									</div>
-									<div class="ui">
-										@if (project.uiLib.includes('Spartan UI')) {
-										<img
-											class="ui-lib"
-											src="/icons/spartan.png"
-											pTooltip="Spartan UI"
-											tooltipPosition="top"
-										/>
-										} @if (project.uiLib.includes('PrimeNG')) {
-										<img
-											class="ui-lib"
-											src="/icons/primeng.svg"
-											pTooltip="PrimeNG"
-											tooltipPosition="top"
-										/>
-										} @if (project.uiLib.includes('Tailwind CSS')) {
-										<img
-											class="ui-lib"
-											src="/icons/tailwind.svg"
-											pTooltip="Tailwind CSS"
-											tooltipPosition="top"
-										/>
-										}
-									</div>
-								</div>
-							</div>
-						</div>
-					</p-card>
-				</a>
-				} }
-			</div>
-		</div>
-	`,
-	styles: [
-		`
-			.content {
-				display: flex;
-				flex-direction: column;
-				align-items: center;
-				justify-content: flex-start;
-				min-height: 80vh;
-				margin: 1rem;
+  selector: 'app-home',
+  standalone: true,
+  imports: [
+    FormsModule,
+    DropdownModule,
+    CardModule,
+    ButtonModule,
+    CheckboxModule,
+    TooltipModule,
+    FilterComponent,
+  ],
+  template: `
+    <div class="content">
+      <div class="filtering">
+        <app-filter
+          [analogVersions]="analogVersions"
+          [angularVersions]="versionGroup"
+          [projectCategories]="categories"
+          [uiLibs]="projectsUIlib"
+          [(ngModel)]="filter"
+        />
 
-				.filtering {
-					display: flex;
-					flex-direction: column;
-					margin-top: 1.5rem;
+        <div class="total">
+          @if (!filterApplied) {
+            <p>All Projects: {{ projects.length }}</p>
+          } @else {
+            <p>Projects found: {{ filteredProjects.length }}</p>
+          }
+        </div>
+      </div>
+      <div class="cards-wrapper">
+        @if (!filterApplied) {
+          @for (project of projects; track project) {
+            <a
+              href="{{ project.url }}?source=builtwithanalog.dev"
+              target="_blank"
+            >
+              <p-card class="home">
+                <img
+                  class="main-image"
+                  src="{{ project.imageSrc }}"
+                  alt="{{ project.name }}"
+                  pTooltip="by {{ project.developer }}"
+                  tooltipPosition="bottom"
+                />
+                <div class="card-content">
+                  <div class="details">
+                    <div class="info">
+                      <div class="main">
+                        @if (
+                          project.category.includes('Open Source') ||
+                          project.pricing === 'Free'
+                        ) {
+                          <h2>{{ project.name }}</h2>
+                        } @else {
+                          <span
+                            class="material-symbols-outlined"
+                            title="{{ project.pricing }}"
+                          >
+                            paid
+                          </span>
+                          <h2>{{ project.name }}</h2>
+                        }
+                      </div>
+                      <div class="more">
+                        <p>{{ project.category }}</p>
+                      </div>
+                    </div>
+                    <div class="features">
+                      <div class="version">
+                        <img
+                          class="analog"
+                          src="/icons/analog.svg"
+                          pTooltip="{{ project.analogVersion }}"
+                          tooltipPosition="top"
+                        />
+                        @if (isVersion16OrAbove(project.version)) {
+                          <img
+                            src="/icons/angular.svg"
+                            pTooltip="{{ project.version }}"
+                            tooltipPosition="top"
+                          />
+                        } @else {
+                          <img
+                            src="/angular-old.svg"
+                            pTooltip="{{ project.version }}"
+                            tooltipPosition="top"
+                          />
+                        }
+                      </div>
+                      <div class="ui">
+                        @if (project.uiLib.includes('Spartan UI')) {
+                          <img
+                            class="ui-lib"
+                            src="/icons/spartan.png"
+                            pTooltip="Spartan UI"
+                            tooltipPosition="top"
+                          />
+                        }
+                        @if (project.uiLib.includes('PrimeNG')) {
+                          <img
+                            class="ui-lib"
+                            src="/icons/primeng.svg"
+                            pTooltip="PrimeNG"
+                            tooltipPosition="top"
+                          />
+                        }
+                        @if (project.uiLib.includes('Tailwind CSS')) {
+                          <img
+                            class="ui-lib"
+                            src="/icons/tailwind.svg"
+                            pTooltip="Tailwind CSS"
+                            tooltipPosition="top"
+                          />
+                        }
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </p-card>
+            </a>
+          }
+        } @else {
+          @for (project of filteredProjects; track project) {
+            <a
+              href="{{ project.url }}?source=builtwithanalog.dev"
+              target="_blank"
+            >
+              <p-card class="home">
+                <img
+                  class="main-image"
+                  src="{{ project.imageSrc }}"
+                  alt="{{ project.name }}"
+                  pTooltip="by {{ project.developer }}"
+                  tooltipPosition="bottom"
+                />
+                <div class="card-content">
+                  <div class="details">
+                    <div class="info">
+                      <div class="main">
+                        @if (
+                          project.category.includes('Open Source') ||
+                          project.pricing === 'Free'
+                        ) {
+                          <h2>{{ project.name }}</h2>
+                        } @else {
+                          <span
+                            class="material-symbols-outlined"
+                            title="{{ project.pricing }}"
+                          >
+                            paid
+                          </span>
+                          <h2>{{ project.name }}</h2>
+                        }
+                      </div>
+                      <div class="more">
+                        <p>{{ project.category }}</p>
+                      </div>
+                    </div>
+                    <div class="features">
+                      <div class="version">
+                        <img
+                          class="analog"
+                          src="/icons/analog.svg"
+                          pTooltip="{{ project.analogVersion }}"
+                          tooltipPosition="top"
+                        />
+                        @if (isVersion16OrAbove(project.version)) {
+                          <img
+                            src="/icons/angular.svg"
+                            pTooltip="{{ project.version }}"
+                            tooltipPosition="top"
+                          />
+                        } @else {
+                          <img
+                            src="/icons/angular-old.svg"
+                            pTooltip="{{ project.uiLib }}"
+                            tooltipPosition="top"
+                          />
+                        }
+                      </div>
+                      <div class="ui">
+                        @if (project.uiLib.includes('Spartan UI')) {
+                          <img
+                            class="ui-lib"
+                            src="/icons/spartan.png"
+                            pTooltip="Spartan UI"
+                            tooltipPosition="top"
+                          />
+                        }
+                        @if (project.uiLib.includes('PrimeNG')) {
+                          <img
+                            class="ui-lib"
+                            src="/icons/primeng.svg"
+                            pTooltip="PrimeNG"
+                            tooltipPosition="top"
+                          />
+                        }
+                        @if (project.uiLib.includes('Tailwind CSS')) {
+                          <img
+                            class="ui-lib"
+                            src="/icons/tailwind.svg"
+                            pTooltip="Tailwind CSS"
+                            tooltipPosition="top"
+                          />
+                        }
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </p-card>
+            </a>
+          }
+        }
+      </div>
+    </div>
+  `,
+  styles: [
+    `
+      .content {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: flex-start;
+        min-height: 80vh;
+        margin: 1rem;
 
-					.filtering-actions {
-						display: flex;
-						align-items: center;
-						gap: 1rem;
+        .filtering {
+          display: flex;
+          flex-direction: column;
+          margin-top: 1.5rem;
 
-						.p-dropdown {
-							width: 13rem;
-						}
+          .total {
+            display: flex;
+            justify-content: center;
+            padding: 0.5rem;
 
-						.buttons-wrapper {
-							display: flex;
-							flex-direction: column;
-							align-items: flex-start;
-							justify-content: center;
-							gap: 0.3rem;
+            p {
+              font-size: 1rem;
+            }
+          }
+        }
 
-							.checkbox-wrapper {
-								display: flex;
-								align-items: center;
-								gap: 0.3rem;
-								margin: 0 0.5rem;
+        .cards-wrapper {
+          display: flex;
+          flex-wrap: wrap;
+          justify-content: center;
+          gap: 1.5rem;
+          margin: 1rem 4rem 2rem;
 
-								.p- checkbox {
-									height: 1.1rem;
-									width: 1.1rem;
-									cursor: pointer;
-								}
-								label {
-									font-size: 1.1rem;
-								}
-							}
-						}
-					}
+          .p-card {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            width: 20rem;
 
-					.total {
-						display: flex;
-						justify-content: center;
-						padding: 0.5rem;
+            img {
+              width: 100%;
+              object-fit: cover;
+              margin-bottom: 0.1rem;
+            }
 
-						p {
-							font-size: 1rem;
-						}
-					}
-				}
+            .card-content {
+              width: 100%;
+              h2 {
+                font-size: 1.1rem;
+                font-weight: 500;
+                margin: 0.6rem 0 0;
+              }
 
-				.cards-wrapper {
-					display: flex;
-					flex-wrap: wrap;
-					justify-content: center;
-					gap: 1.5rem;
-					margin: 1rem 4rem 2rem;
+              p {
+                font-size: 0.9rem;
+                margin: 0;
+              }
 
-					.p-card {
-						display: flex;
-						flex-direction: column;
-						align-items: center;
-						width: 20rem;
+              .details {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
 
-						img {
-							width: 100%;
-							object-fit: cover;
-							margin-bottom: 0.1rem;
-						}
+                .info {
+                  .main {
+                    display: flex;
+                    align-items: center;
+                    gap: 0.2rem;
 
-						.card-content {
-							width: 100%;
-							h2 {
-								font-size: 1.1rem;
-								font-weight: 500;
-								margin: 0.6rem 0 0;
-							}
+                    span {
+                      color: #36744c;
+                    }
+                  }
+                }
 
-							p {
-								font-size: 0.9rem;
-								margin: 0;
-							}
+                .features {
+                  display: flex;
+                  padding: 0 0.5rem 0.5rem;
+                  gap: 0.3rem;
 
-							.details {
-								display: flex;
-								justify-content: space-between;
-								align-items: center;
+                  img {
+                    width: 1.5rem;
+                    height: 1.5rem;
 
-								.info {
-									.main {
-										display: flex;
-										align-items: center;
-										gap: 0.2rem;
+                    &.ui-lib {
+                      margin-top: 0.3rem;
+                    }
+                  }
 
-										span {
-											color: #36744c;
-										}
-									}
-								}
+                  .version {
+                    display: flex;
+                    align-items: center;
+                    img {
+                      object-fit: contain;
+                      &.analog {
+                        width: 2rem;
+                        height: 2rem;
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
 
-								.features {
-									display: flex;
-									padding: 0 0.5rem 0.5rem;
-									gap: 0.3rem;
+      @media (max-width: 768px) {
+        .content {
+          .filtering-actions {
+            flex-direction: column;
+            gap: 0;
+          }
 
-									img {
-										width: 1.5rem;
-										height: 1.5rem;
+          .cards-wrapper {
+            flex-direction: column;
+            align-items: center;
 
-										&.ui-lib {
-											margin-top: 0.3rem;
-										}
-									}
-
-									.version {
-										display: flex;
-										align-items: center;
-										img {
-											object-fit: contain;
-											&.analog {
-												width: 2rem;
-												height: 2rem;
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-
-			@media (max-width: 768px) {
-				.content {
-					.filtering-actions {
-						flex-direction: column;
-						gap: 0;
-					}
-
-					.cards-wrapper {
-						flex-direction: column;
-						align-items: center;
-
-						.p-card {
-							width: 80vw;
-						}
-					}
-				}
-			}
-		`,
-	],
+            .p-card {
+              width: 80vw;
+            }
+          }
+        }
+      }
+    `,
+  ],
 })
 export default class HomeComponent implements OnInit, OnChanges {
-	projects: Project[] = [];
-	filteredProjects: Project[] = [];
-	categories: { name: string }[] = [];
-	versionGroup: { name: string }[] = [];
-	analogVersions: { name: string }[] = [];
-	projectsUIlib: { name: string }[] = [];
-	filterApplied: boolean = false;
-	selectedCategory: { name: "" } = { name: "" };
-	selectedVersionGroup: { name: "" } = { name: "" };
-	selectedAnalogVersion: { name: "" } = { name: "" };
-	selectedUIlib: { name: "" } = { name: "" };
-	showFree: boolean = false;
-	threeDElements: boolean = false;
-	http = inject(HttpClient);
+  projects: Project[] = [];
+  filteredProjects: Project[] = [];
+  categories: string[] = [];
+  versionGroup: string[] = [];
+  analogVersions: string[] = [];
+  projectsUIlib: string[] = [];
+  filterApplied: boolean = false;
+  selectedCategory: string | null = null;
+  selectedVersionGroup: string | null = null;
+  selectedAnalogVersion: string | null = null;
+  selectedUIlib: string | null = null;
+  showFree: boolean | null = null;
+  threeDElements: boolean | null = null;
 
-	ngOnInit(): void {
-		this.filterApplied = false;
-		this.http
-			.get<Project[]>("https://builtwithanalog.dev/api/projects")
-			.subscribe((projects) => {
-				this.projects = projects;
-				this.categories = Array.from(
-					new Set(this.projects.map((project) => project.category))
-				).map((category) => ({ name: category }));
-				this.versionGroup = Array.from(
-					new Set(this.projects.map((project) => project.versionGroup))
-				).map((versionGroup) => ({ name: versionGroup }));
-				this.analogVersions = Array.from(
-					new Set(this.projects.map((project) => project.analogVersion))
-				).map((analogVersion) => ({ name: analogVersion }));
-				this.projectsUIlib = Array.from(
-					new Set(
-						this.projects.map((project) => project.uiLib.split(", ")).flat()
-					)
-				).map((uiLib) => ({ name: uiLib }));
-			});
-	}
+  http = inject(HttpClient);
+  readonly #route = inject(ActivatedRoute);
+  readonly #router = inject(Router);
 
-	ngOnChanges(): void {
-		this.filterApplied = false;
-		this.http
-			.get<Project[]>("https://builtwithanalog.dev/api/projects")
-			.subscribe((projects) => {
-				this.projects = projects;
-				this.categories = Array.from(
-					new Set(this.projects.map((project) => project.category))
-				).map((category) => ({ name: category }));
-				this.versionGroup = Array.from(
-					new Set(this.projects.map((project) => project.versionGroup))
-				).map((versionGroup) => ({ name: versionGroup }));
-				this.analogVersions = Array.from(
-					new Set(this.projects.map((project) => project.analogVersion))
-				).map((analogVersion) => ({ name: analogVersion }));
-				this.projectsUIlib = Array.from(
-					new Set(
-						this.projects.map((project) => project.uiLib.split(", ")).flat()
-					)
-				).map((uiLib) => ({ name: uiLib }));
-			});
-	}
+  readonly filter = model<Filter>({
+    analogVersion: null,
+    category: null,
+    uiLib: null,
+    versionGroup: null,
+    isUsing3D: null,
+    isFree: null,
+  });
 
-	applyFilter(): void {
-		this.filterApplied = true;
-		this.filteredProjects = this.projects.filter((project) => {
-			return (
-				(this.selectedCategory.name === "" ||
-					project.category === this.selectedCategory.name) &&
-				(this.selectedAnalogVersion.name === "" ||
-					project.analogVersion === this.selectedAnalogVersion.name) &&
-				(this.selectedUIlib.name === "" ||
-					project.uiLib.split(", ").includes(this.selectedUIlib.name)) &&
-				(this.selectedVersionGroup.name === "" ||
-					project.versionGroup === this.selectedVersionGroup.name) &&
-				(!this.showFree || project.pricing === "Free") &&
-				(!this.threeDElements || project.threeD === true)
-			);
-		});
-	}
+  constructor() {
+    const syncFiltersEffect = effect(() => {
+      const filter = this.filter();
+      untracked(() => this.updateFilter(filter));
+    });
+  }
 
-	clearFilters(): void {
-		this.filterApplied = false;
-		this.selectedCategory = { name: "" };
-		this.selectedAnalogVersion = { name: "" };
-		this.selectedUIlib = { name: "" };
-		this.selectedVersionGroup = { name: "" };
-		this.showFree = false;
-		this.threeDElements = false;
-	}
+  ngOnInit(): void {
+    this.filterApplied = false;
+    this.http
+      .get<Project[]>('https://builtwithanalog.dev/api/projects')
+      .subscribe((projects) => {
+        this.projects = projects;
+        this.categories = Array.from(
+          new Set(this.projects.map((project) => project.category)),
+        );
 
-	isVersion16OrAbove(version: string): boolean {
-		const majorVersion = parseInt(version.split(".")[0], 10);
-		return majorVersion >= 16;
-	}
+        this.versionGroup = Array.from(
+          new Set(this.projects.map((project) => project.versionGroup)),
+        );
+
+        this.analogVersions = Array.from(
+          new Set(this.projects.map((project) => project.analogVersion)),
+        );
+
+        this.projectsUIlib = Array.from(
+          new Set(
+            this.projects.map((project) => project.uiLib.split(', ')).flat(),
+          ),
+        );
+
+        this.#seedFilter();
+      });
+  }
+
+  ngOnChanges(): void {
+    this.filterApplied = false;
+    this.http
+      .get<Project[]>('https://builtwithanalog.dev/api/projects')
+      .subscribe((projects) => {
+        this.projects = projects;
+        this.categories = Array.from(
+          new Set(this.projects.map((project) => project.category)),
+        ).map((category) => ({ name: category }));
+        this.versionGroup = Array.from(
+          new Set(this.projects.map((project) => project.versionGroup)),
+        ).map((versionGroup) => ({ name: versionGroup }));
+        this.analogVersions = Array.from(
+          new Set(this.projects.map((project) => project.analogVersion)),
+        ).map((analogVersion) => ({ name: analogVersion }));
+        this.projectsUIlib = Array.from(
+          new Set(
+            this.projects.map((project) => project.uiLib.split(', ')).flat(),
+          ),
+        ).map((uiLib) => ({ name: uiLib }));
+      });
+  }
+
+  applyFilter(): void {
+    this.filterApplied = true;
+    this.filteredProjects = this.projects.filter((project) => {
+      return (
+        (this.selectedCategory === null ||
+          project.category === this.selectedCategory) &&
+        (this.selectedAnalogVersion === null ||
+          project.analogVersion === this.selectedAnalogVersion) &&
+        (this.selectedUIlib === null ||
+          project.uiLib.split(', ').includes(this.selectedUIlib)) &&
+        (this.selectedVersionGroup === null ||
+          project.versionGroup === this.selectedVersionGroup) &&
+        (this.showFree === null || this.showFree
+          ? project.pricing === 'Free'
+          : project.pricing !== 'Free') &&
+        (this.threeDElements === null || project.threeD === this.threeDElements)
+      );
+    });
+  }
+
+  clearFilters(): void {
+    this.filterApplied = false;
+    this.selectedCategory = { name: '' };
+    this.selectedAnalogVersion = { name: '' };
+    this.selectedUIlib = { name: '' };
+    this.selectedVersionGroup = { name: '' };
+    this.showFree = false;
+    this.threeDElements = false;
+  }
+
+  updateFilter(filter: Filter): void {
+    this.selectedAnalogVersion = filter.analogVersion;
+    this.selectedCategory = filter.category;
+    this.selectedUIlib = filter.uiLib;
+    this.selectedVersionGroup = filter.versionGroup;
+    this.threeDElements = filter.isUsing3D;
+    this.showFree = filter.isFree;
+
+    this.applyFilter();
+    this.#updateQueryParams(filter);
+
+    const hasAnyFilterBeenSet = Object.values(filter).some(
+      (filter) => filter !== null,
+    );
+
+    this.filterApplied = hasAnyFilterBeenSet;
+  }
+
+  #seedFilter(): void {
+    const queryParams = this.#route.snapshot.queryParams;
+
+    const asBoolean = (param: 'true' | 'false' | null) =>
+      param === 'true' ? true : param === 'false' ? false : null;
+
+    const filter: Filter = {
+      analogVersion: queryParams['analogVersion'] ?? null,
+      category: queryParams['category'] ?? null,
+      uiLib: queryParams['uiLib'] ?? null,
+      versionGroup: queryParams['versionGroup'] ?? null,
+      isUsing3D: asBoolean(queryParams['isUsing3D']),
+      isFree: asBoolean(queryParams['isFree']),
+    };
+
+    this.filter.set(filter);
+  }
+
+  #updateQueryParams(filter: Filter): void {
+    const queryParams = Object.entries(filter)
+      .filter(([, value]) => value !== null)
+      .reduce((x, [k, v]) => ({ ...x, [k]: v }), {});
+
+    this.#router.navigate([], {
+      relativeTo: this.#route,
+      queryParams: queryParams,
+    });
+  }
+
+  isVersion16OrAbove(version: string): boolean {
+    const majorVersion = parseInt(version.split('.')[0], 10);
+    return majorVersion >= 16;
+  }
 }

--- a/src/app/pages/(home).page.ts
+++ b/src/app/pages/(home).page.ts
@@ -255,11 +255,6 @@ import { toSignal } from '@angular/core/rxjs-interop';
 
       @media (max-width: 768px) {
         .content {
-          .filtering-actions {
-            flex-direction: column;
-            gap: 0;
-          }
-
           .cards-wrapper {
             flex-direction: column;
             align-items: center;


### PR DESCRIPTION
## This PR Closes Issue 

Closes #61

## Description

This PR introduce several changes, induced by the synchronization of the filter with the query parameters:

- feat: The filter is now set in a dedicated component
- feat: The flags (free? 3D?) are now using three states: yes / no / unset
- refacto: The filter as well as the options and selected values are exposed as signals
- refacto: The computed values (filtered projects, flag indicating if any filter is set) are now using signals as well

## What type of PR is this? (check all applicable)

- [ ] 🅰️ Project Submission
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [x] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Mobile & Desktop Screenshots/Recordings

Here is the final result:

![Animation](https://github.com/user-attachments/assets/7340138d-654d-425c-916c-35a20989017c)

And the aspect on mobile:

![image](https://github.com/user-attachments/assets/fbeeb447-4601-42b2-b8a5-14a5a70ff33b)


## Steps to QA

- Set a filter
- Ensure that the projects are correctly filtered
- Ensure that the projects count is valid
- Ensure that the filters are in the URL as query parameters

- Clear the filters
- Ensure that all projects are visible
- Ensure that the projects count is valid
- Ensure that no query parameters are set

- Artificially set query parameters
- Navigate to the URL
- Ensure that the filters are correctly set

## Added to documentation?
- [ ] 📜 README.md
- [ ] 📜 CONTRIBUTING.md
- [x] 🙅 no documentation needed

## [Optional] Post-deployment tasks

N/A

## [Optional] What gif best describes this PR or how it makes you feel? 

N/A




